### PR TITLE
fix: correct file size calculation (bits / bytes conversion)

### DIFF
--- a/src/Lidarr.Plugin.Qobuz/Indexers/Qobuz/QobuzParser.cs
+++ b/src/Lidarr.Plugin.Qobuz/Indexers/Qobuz/QobuzParser.cs
@@ -106,7 +106,7 @@ namespace NzbDrone.Core.Indexers.Qobuz
                 AudioQuality.FLACHiRes24Bit192Khz => 9216000,
                 _ => 320000
             };
-            size = x.Duration.Value * bps;
+            size = (x.Duration.Value * bps) / 8;
 
             result.Size = size;
             result.Title = $"{x.Artist.Name} - {x.CompleteTitle}";


### PR DESCRIPTION
### Summary
Fixes incorrect file size reported for downloads. The size was calculated as `duration * bitrate` but the result should be in bits rather than bytes, causing sizes to be reported 8x larger

### Issue
- A 16/44.1 FLAC album (265 MB actual) was reported as 3.1 GB
- This prevented auto-downloads even when the file matched the set quality profile (500–1411 kbps)
- `size = duration * bps` produces bits, Lidarr expects bytes